### PR TITLE
chore: ci build to update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,11 @@ jobs:
       - name: Install
         run: pnpm install
 
-      - name: Build
-        run: pnpm build
-
       - name: Build Extension
-        run: pnpm pack:crx && pnpm pack:zip
+        run: pnpm build
 
       - name: Upload Zip
         uses: actions/upload-artifact@v3
         with:
           name: BewlyBewly Zip
-          path: extension.zip
-
-      - name: Upload Crx
-        uses: actions/upload-artifact@v3
-        with:
-          name: BewlyBewly Crx
-          path: extension.crx
+          path: extension


### PR DESCRIPTION
在action下载的压缩包可以直接安装了，不需要解压