### PR TITLE
Hide search history dropdown on input blur

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "postinstall": "npx simple-git-hooks"
   },
   "dependencies": {
-    "@types/md5": "^2.3.5",
     "dplayer": "^1.27.1",
     "md5": "^2.3.0",
     "mitt": "^3.0.1",
@@ -52,6 +51,7 @@
     "@iconify/vue": "^4.1.1",
     "@intlify/unplugin-vue-i18n": "^0.8.2",
     "@rollup/plugin-replace": "^5.0.5",
+    "@types/md5": "^2.3.5",
     "@types/dplayer": "^1.25.5",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^18.18.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@types/md5':
-    specifier: ^2.3.5
-    version: 2.3.5
   dplayer:
     specifier: ^1.27.1
     version: 1.27.1
@@ -64,6 +61,9 @@ devDependencies:
   '@types/fs-extra':
     specifier: ^9.0.13
     version: 9.0.13
+  '@types/md5':
+    specifier: ^2.3.5
+    version: 2.3.5
   '@types/node':
     specifier: ^18.18.10
     version: 18.19.6
@@ -1258,7 +1258,7 @@ packages:
 
   /@types/md5@2.3.5:
     resolution: {integrity: sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==}
-    dev: false
+    dev: true
 
   /@types/mdast@3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -173,6 +173,7 @@ async function handleClearSearchHistory() {
         ring="1 $bew-border-color"
         transition="all duration-300"
         type="text"
+        @blur="isFocus = false"
         @focus="isFocus = true"
         @input="handleInput"
         @keyup.enter.stop.passive="navigateToSearchResultPage(keyword)"


### PR DESCRIPTION
Resolves an issue where the search history dropdown was not properly hidden when the input field lost focus, specifically when pressing 'esc' while the input was in focus.

