### PR TITLE
fix: 消息中心页深色模式适配

### DIFF
--- a/src/styles/adaptedStyles/notificationsPage.scss
+++ b/src/styles/adaptedStyles/notificationsPage.scss
@@ -189,7 +189,8 @@
       .orginal-reply,
       .content .input-section .row .emoji-btn,
       .content .btnrow .btn.save.disabled,
-      .content .btnrow .btn.clear {
+      .content .btnrow .btn.clear,
+      .msg-push-new__leave-message--text {
         color: var(--bew-text-2);
       }
 
@@ -238,7 +239,9 @@
 
       .config .config-item:not(:first-child)::before,
       .bili-im .msg-notify hr,
-      .divider-last::before, .divider-last::after {
+      .divider-last::before, .divider-last::after,
+      .header::after,
+      .split-line {
         background-color: var(--bew-border-color);
       }
 
@@ -255,7 +258,8 @@
       .send-btn:not(.active),
       .toggle,
       .content .btnrow .btn.save.disabled,
-      .reply-textarea {
+      .reply-textarea,
+      .list-item.top {
         background-color: var(--bew-fill-1);
       }
 
@@ -264,7 +268,8 @@
       .bp-emoji-box .emoji-cover.selected,
       .bp-emoji-box .emoji:hover,
       .bp-emoji-box2 .emoji-cover.selected,
-      .bp-emoji-box2 .emoji:hover {
+      .bp-emoji-box2 .emoji:hover,
+      .msg-push-new__leave-message {
         background-color: var(--bew-fill-2);
       }
 


### PR DESCRIPTION
<!-- Description of the PR: https://github.com/hakadao/BewlyBewly?tab=readme-ov-file#-contribution -->
<!-- PR 说明: https://github.com/hakadao/BewlyBewly/blob/main/README-cmn_CN.md#-%E8%B4%A1%E7%8C%AE -->
<!-- PR 說明: https://github.com/hakadao/BewlyBewly/blob/main/README-cmn_TW.md#-%E8%B2%A2%E7%8D%BB -->
<!-- PR 說明（廣東話）: https://github.com/hakadao/BewlyBewly/blob/main/README-jyut.md#-%E8%B2%A2%E7%8D%BB -->
用vsc本地编辑没这个问题了
(~~我是傻逼我把git怎么撤回给忘了还现去复习了下~~)
![信息界面收到的赞页最新和累计分割线](https://github.com/hakadao/BewlyBewly/assets/56493273/b557f412-6d8d-4d71-9fb2-7c5be33de0c5)
![信息界面私信推送视频卡片说明适配](https://github.com/hakadao/BewlyBewly/assets/56493273/3462f6ba-fb48-4ef4-a0bc-4677be4795b7)
![信息界面置顶聊天深色适配](https://github.com/hakadao/BewlyBewly/assets/56493273/1390c11e-0c62-4ef3-bcdc-45997a117363)
