### PR TITLE
fix: misplaced of switch button

### DIFF
--- a/src/components/Radio.vue
+++ b/src/components/Radio.vue
@@ -39,6 +39,10 @@ label {
   --b-border-width: 2px;
 }
 
+input[type="checkbox"] + span::after {
+  box-sizing: border-box;
+}
+
 input[type="checkbox"]{
 
   &:hover + span {


### PR DESCRIPTION
<!-- Description of the PR: https://github.com/hakadao/BewlyBewly?tab=readme-ov-file#-contribution -->
<!-- PR 说明: https://github.com/hakadao/BewlyBewly/blob/main/README-cmn_CN.md#-%E8%B4%A1%E7%8C%AE -->
<!-- PR 說明: https://github.com/hakadao/BewlyBewly/blob/main/README-cmn_TW.md#-%E8%B2%A2%E7%8D%BB -->
<!-- PR 說明（廣東話）: https://github.com/hakadao/BewlyBewly/blob/main/README-jyut.md#-%E8%B2%A2%E7%8D%BB -->

修复了 #538 的问题。

修正了Firefox和Chrome下的滑动按钮渲染一致性。